### PR TITLE
Set up initial playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+/out/
+/resources/public/js/compiled/
+/target/
+/*-init.clj
+/*.log
+
+# Leiningen
+/.lein-*
+/.nrepl-port
+
+# Node.js dependencies
+/node_modules/
+
+# shadow-cljs cache, port files
+/shadow-cljs.edn
+/.shadow-cljs/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 # shadow-cljs cache, port files
 /shadow-cljs.edn
 /.shadow-cljs/
+
+# npm
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # Metafacture Playground
 
 This is an approach to provide a web application to play around with Metafactures languages Fix and Flux inspired by the [JSON-LD Playground](https://json-ld.org/playground/).
+This project is inititially created using the [leiningen re-frame template](https://github.com/day8/re-frame-template).
+
+## Installation
+
+Before starting yo need to install [Leiningen](https://leiningen.org/) and a JDK.
+
+Clone the metafacture-playground project
+
+```bash
+$ git clone https://github.com/metafacture/metafacture-playground.git
+$ cd metafacture-playground
+```
+
+Start the application:
+```bash
+$ lein watch
+```
+
+Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
+

--- a/README.md
+++ b/README.md
@@ -126,29 +126,8 @@ Run
 lein test
 ```
 
-### Production Build
+## Run workflows on the web server
 
-To compile clojurescript to javascript:
-
-```
-lein release
-```
-
-Create uberjar
-
-```
-lein clean
-lein uberjar
-```
-
-The jar started with
-
-```
-java -jar target/metafacture-playground.jar
-```
-
-runs under http://localhost:3000.
-
-Run workflows on the web server, passing `data`, `flux`, and `fix`:
+Run workflows on the web server, passing `data`, `flux`, and `fix` as GET-Parameter:
 
 [http://localhost:3000/process?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:3000/process?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ git clone https://github.com/metafacture/metafacture-playground.git
 $ cd metafacture-playground
 ```
 
-### Start the application (only frontend):
+### Start the application
 
 ```
 lein watch
@@ -54,7 +54,7 @@ lein watch
 
 Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
 
-### Start the application (frontend + backend)
+### Start the server
 To compile and build the frontend run:
 
 ```
@@ -73,6 +73,7 @@ Run workflows on the web server, passing `data`, `flux`, and `fix`:
 
 ### Run tests
 
+### clj tests
 Install karma and headless chrome
 
 ```
@@ -89,6 +90,13 @@ And in another terminal:
 
 ```
 karma start
+```
+
+### clj tests
+
+Run
+```
+lein test
 ```
 
 ### Production Build

--- a/README.md
+++ b/README.md
@@ -3,9 +3,24 @@
 This is an approach to provide a web application to play around with Metafactures languages Fix and Flux inspired by the [JSON-LD Playground](https://json-ld.org/playground/).
 This project is inititially created using the [leiningen re-frame template](https://github.com/day8/re-frame-template).
 
+The current test deployment is available at [http://test.lobid.org/playground/](http://test.lobid.org/playground/)
+
 ## Installation
 
-Before starting yo need to install [Leiningen](https://leiningen.org/) and a JDK (minimum Java 8).
+Before starting you need to install [Leiningen](https://leiningen.org/) and a JDK (minimum Java 8).
+
+### Install Leiningen
+
+General setup on Unix (see [https://leiningen.org/](https://leiningen.org/) for other options):
+
+```bash
+mkdir ~/bin
+wget -O ~/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein
+chmod a+x ~/bin/lein
+```
+
+### Install Metafacture
+
 This project depends on [metafacture-core](https://github.com/metafacture/metafacture-core) and [metafacture-fix](https://github.com/metafacture/metafacture-fix). Clone and install both repositories (branch oersi).
 
 Clone and install metafacture-fix:
@@ -23,6 +38,7 @@ Windows:
 ```bash
 $ .\gradlew.bat install
 ```
+
 Clone and install metafacture-core:
 ```bash
 $ git clone --branch oersi https://github.com/metafacture/metafacture-core.git
@@ -39,7 +55,7 @@ Windows:
 $ .\gradlew.bat install
 ```
 
-Clone the metafacture-playground project
+### Clone the metafacture-playground project
 
 ```bash
 $ git clone https://github.com/metafacture/metafacture-playground.git
@@ -55,29 +71,39 @@ lein watch
 Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
 
 ### Start the server
+
 To compile and build the frontend run:
 
 ```
 lein release
 ```
+
 Then start the server with:
 
 ```
 lein run
 ```
+
 Browse to http://localhost:3000.
 
 Run workflows on the web server, passing `data`, `flux`, and `fix`:
 
-[http://localhost:8080/xtext-service/run?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:8080/xtext-service/run?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))
+[http://localhost:3000/process?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:3000/process?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))
 
 ### Run tests
 
 ### clj tests
+
 Install karma and headless chrome
 
 ```
 npm install -g karma-cli
+```
+
+Point to your Chrome binary, e.g.
+
+```
+export CHROME_BIN='/usr/bin/chromium-browser'
 ```
 
 And then run your tests
@@ -95,6 +121,7 @@ karma start
 ### clj tests
 
 Run
+
 ```
 lein test
 ```
@@ -114,12 +141,14 @@ lein clean
 lein uberjar
 ```
 
-The jar startet with
+The jar started with
 
 ```
-java -jar metafacture-playground.jar
+java -jar target/metafacture-playground.jar
 ```
+
 runs under http://localhost:3000.
+
 Run workflows on the web server, passing `data`, `flux`, and `fix`:
 
-[http://localhost:8080/xtext-service/run?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:8080/xtext-service/run?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))
+[http://localhost:3000/process?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:3000/process?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ chmod a+x ~/bin/lein
 
 This project depends on [metafacture-core](https://github.com/metafacture/metafacture-core) and [metafacture-fix](https://github.com/metafacture/metafacture-fix). Clone and install both repositories (branch oersi).
 
-Clone and install metafacture-fix:
+Clone and install metafacture-core:
 ```bash
-$ git clone --branch oersi https://github.com/metafacture/metafacture-fix.git
-$ cd metafacture-fix
+$ git clone --branch oersi https://github.com/metafacture/metafacture-core.git
+$ cd metafacture-core
 ```
 
 Unix:
@@ -39,10 +39,10 @@ Windows:
 $ .\gradlew.bat install
 ```
 
-Clone and install metafacture-core:
+Clone and install metafacture-fix:
 ```bash
-$ git clone --branch oersi https://github.com/metafacture/metafacture-core.git
-$ cd metafacture-core
+$ git clone --branch oersi https://github.com/metafacture/metafacture-fix.git
+$ cd metafacture-fix
 ```
 
 Unix:
@@ -62,7 +62,7 @@ $ git clone https://github.com/metafacture/metafacture-playground.git
 $ cd metafacture-playground
 ```
 
-### Start the application
+### Start the frontend in development mode
 
 ```
 lein watch
@@ -70,7 +70,7 @@ lein watch
 
 Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
 
-### Start the server
+### Start the frontend and backend server
 
 To compile and build the frontend run:
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,52 @@ $ git clone https://github.com/metafacture/metafacture-playground.git
 $ cd metafacture-playground
 ```
 
-Start the application:
-```bash
-$ lein watch
+### Start the application:
+
+```
+lein watch
 ```
 
 Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
 
+### Run tests
+
+Install karma and headless chrome
+
+```
+npm install -g karma-cli
+```
+
+And then run your tests
+
+```
+lein watch
+```
+
+And in another terminal:
+
+```
+karma start
+```
+
+### Production Build
+
+To compile clojurescript to javascript:
+
+```
+lein release
+```
+
+Create uberjar
+
+```
+lein clean
+lein uberjar
+```
+
+The jar startet with
+
+```
+java -jar metafacture-playground.jar
+```
+runs under http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -5,7 +5,39 @@ This project is inititially created using the [leiningen re-frame template](http
 
 ## Installation
 
-Before starting yo need to install [Leiningen](https://leiningen.org/) and a JDK.
+Before starting yo need to install [Leiningen](https://leiningen.org/) and a JDK (minimum Java 8).
+This project depends on [metafacture-core](https://github.com/metafacture/metafacture-core) and [metafacture-fix](https://github.com/metafacture/metafacture-fix). Clone and install both repositories (branch oersi).
+
+Clone and install metafacture-fix:
+```bash
+$ git clone --branch oersi https://github.com/metafacture/metafacture-fix.git
+$ cd metafacture-fix
+```
+
+Unix:
+```bash
+$ ./gradlew install
+```
+
+Windows:
+```bash
+$ .\gradlew.bat install
+```
+Clone and install metafacture-core:
+```bash
+$ git clone --branch oersi https://github.com/metafacture/metafacture-core.git
+$ cd metafacture-core
+```
+
+Unix:
+```bash
+$ ./gradlew install
+```
+
+Windows:
+```bash
+$ .\gradlew.bat install
+```
 
 Clone the metafacture-playground project
 
@@ -14,13 +46,30 @@ $ git clone https://github.com/metafacture/metafacture-playground.git
 $ cd metafacture-playground
 ```
 
-### Start the application:
+### Start the application (only frontend):
 
 ```
 lein watch
 ```
 
 Wait a bit, perhaps 20 seconds, keeping an eye out for a sign the compile has finished, then browse to http://localhost:8280.
+
+### Start the application (frontend + backend)
+To compile and build the frontend run:
+
+```
+lein release
+```
+Then start the server with:
+
+```
+lein run
+```
+Browse to http://localhost:3000.
+
+Run workflows on the web server, passing `data`, `flux`, and `fix`:
+
+[http://localhost:8080/xtext-service/run?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:8080/xtext-service/run?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))
 
 ### Run tests
 
@@ -62,4 +111,7 @@ The jar startet with
 ```
 java -jar metafacture-playground.jar
 ```
-runs under http://localhost:3000
+runs under http://localhost:3000.
+Run workflows on the web server, passing `data`, `flux`, and `fix`:
+
+[http://localhost:8080/xtext-service/run?data='1'{'a': '5', 'z': 10}&flux=as-lines|decode-formeta|fix|encode-formeta(style="multiline")&fix=map(a,b) map(_else)](http://localhost:8080/xtext-service/run?data=%271%27{%27a%27:%20%275%27,%20%27z%27:%2010}&flux=as-lines|decode-formeta|fix|encode-formeta(style=%22multiline%22)&fix=map(a,c)%20map(_else))

--- a/dev/cljs/user.cljs
+++ b/dev/cljs/user.cljs
@@ -1,0 +1,8 @@
+(ns cljs.user
+  "Commonly used symbols for easy access in the ClojureScript REPL during
+  development."
+  (:require
+    [cljs.repl :refer (Error->map apropos dir doc error->str ex-str ex-triage
+                       find-doc print-doc pst source)]
+    [clojure.pprint :refer (pprint)]
+    [clojure.string :as str]))

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,27 @@
+module.exports = function (config) {
+  var junitOutputDir = process.env.CIRCLE_TEST_REPORTS || "target/junit"
+
+  config.set({
+    browsers: ['ChromeHeadless'],
+    basePath: 'target',
+    files: ['karma-test.js'],
+    frameworks: ['cljs-test'],
+    plugins: [
+        'karma-cljs-test',
+        'karma-chrome-launcher',
+        'karma-junit-reporter'
+    ],
+    colors: true,
+    logLevel: config.LOG_INFO,
+    client: {
+      args: ['shadow.test.karma.init']
+    },
+
+    // the default configuration
+    junitReporter: {
+      outputDir: junitOutputDir + '/karma', // results will be saved as outputDir/browserName.xml
+      outputFile: undefined, // if included, results will be saved as outputDir/browserName/outputFile
+      suite: '' // suite will become the package name attribute in xml testsuite element
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,15 @@
 {
 	"name": "metafacture-playground",
-	"dependencies": {},
-	"devDependencies": {}
+	"dependencies": {
+		"react": "16.13.0",
+		"react-dom": "16.13.0"
+	},
+	"devDependencies": {
+		"karma": "5.2.3",
+		"karma-chrome-launcher": "3.1.0",
+		"karma-cli": "^2.0.0",
+		"karma-cljs-test": "0.1.0",
+		"karma-junit-reporter": "2.0.1",
+		"shadow-cljs": "2.11.7"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"name": "metafacture-playground",
+	"dependencies": {},
+	"devDependencies": {}
+}

--- a/project.clj
+++ b/project.clj
@@ -10,10 +10,17 @@
                  [re-frame "1.1.2"]
                  [compojure "1.6.2"]
                  [yogthos/config "1.1.7"]
-                 [ring "1.8.2"]]
+                 [ring "1.8.2"]
+                 [org.metafacture/metafacture-commons "feature-oersi-SNAPSHOT"]
+                 [org.metafacture/metafacture-formeta "feature-oersi-SNAPSHOT"]
+                 [org.metafacture/metafacture-mangling "feature-oersi-SNAPSHOT"]
+                 [org.metafacture/metafacture-runner "feature-oersi-SNAPSHOT"]
+                 [org.metafacture/metafacture-xml "feature-oersi-SNAPSHOT"]
+                 [org.eclipse.xtext/xtext-dev-bom "2.17.0" :extension "pom"]
+                 [org.metafacture.fix/org.metafacture.fix "1.0.0-SNAPSHOT" :exclusions [[org.eclipse.xtext/xtext-dev-bom]]]]
 
   :plugins [[lein-shadow "0.3.1"]
-            
+
             [lein-shell "0.5.0"]]
 
   :min-lein-version "2.9.0"
@@ -27,7 +34,7 @@
 
 
   :shadow-cljs {:nrepl {:port 8777}
-                
+
                 :builds {:app {:target :browser
                                :output-dir "resources/public/js/compiled"
                                :asset-path "/js/compiled"
@@ -36,8 +43,7 @@
 
                                :devtools {:http-root "resources/public"
                                           :http-port 8280
-                                          :http-handler metafacture-playground.handler/dev-handler
-                                          }}
+                                          :http-handler metafacture-playground.handler/dev-handler}}
                          :browser-test
                          {:target :browser-test
                           :ns-regexp "-test$"
@@ -50,14 +56,14 @@
                          {:target :karma
                           :ns-regexp "-test$"
                           :output-to "target/karma-test.js"}}}
-  
+
   :shell {:commands {"karma" {:windows         ["cmd" "/c" "karma"]
                               :default-command "karma"}
                      "open"  {:windows         ["cmd" "/c" "start"]
                               :macosx          "open"
                               :linux           "xdg-open"}}}
 
-  :aliases {"dev"          ["do" 
+  :aliases {"dev"          ["do"
                             ["shell" "echo" "\"DEPRECATED: Please use lein watch instead.\""]
                             ["watch"]]
             "watch"        ["with-profile" "dev" "do"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,10 @@
                                org.clojure/google-closure-library-third-party]]
                  [thheller/shadow-cljs "2.11.7"]
                  [reagent "0.10.0"]
-                 [re-frame "1.1.2"]]
+                 [re-frame "1.1.2"]
+                 [compojure "1.6.2"]
+                 [yogthos/config "1.1.7"]
+                 [ring "1.8.2"]]
 
   :plugins [[lein-shadow "0.3.1"]
             
@@ -33,6 +36,7 @@
 
                                :devtools {:http-root "resources/public"
                                           :http-port 8280
+                                          :http-handler metafacture-playground.handler/dev-handler
                                           }}
                          :browser-test
                          {:target :browser-test
@@ -83,7 +87,12 @@
     :source-paths ["dev"]}
 
    :prod {}
-   
-}
+
+   :uberjar {:source-paths ["env/prod/clj"]
+             :omit-source  true
+             :main         metafacture-playground.server
+             :aot          [metafacture-playground.server]
+             :uberjar-name "metafacture-playground.jar"
+             :prep-tasks   ["compile" ["release"]]}}
 
   :prep-tasks [])

--- a/project.clj
+++ b/project.clj
@@ -11,6 +11,7 @@
                  [compojure "1.6.2"]
                  [yogthos/config "1.1.7"]
                  [ring "1.8.2"]
+                 [day8.re-frame/http-fx "0.2.2"]
                  [org.metafacture/metafacture-commons "feature-oersi-SNAPSHOT"]
                  [org.metafacture/metafacture-formeta "feature-oersi-SNAPSHOT"]
                  [org.metafacture/metafacture-mangling "feature-oersi-SNAPSHOT"]
@@ -27,7 +28,7 @@
 
   :source-paths ["src/clj" "src/cljs"]
 
-  :test-paths   ["test/cljs"]
+  :test-paths   ["test/cljs" "test/clj"]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
                                     "test/js"]

--- a/project.clj
+++ b/project.clj
@@ -81,6 +81,8 @@
                             ["shadow" "compile" "karma-test"]
                             ["shell" "karma" "start" "--single-run" "--reporters" "junit,dots"]]}
 
+  :main metafacture-playground.server
+
   :profiles
   {:dev
    {:dependencies [[binaryage/devtools "1.0.2"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,5 @@
 (defproject metafacture-playground "0.1.0-SNAPSHOT"
+  :description "Web application to play around with workflows using Metafacture languages Fix and Flux"
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.773"
                   :exclusions [com.google.javascript/closure-compiler-unshaded

--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,88 @@
+(defproject metafacture-playground "0.1.0-SNAPSHOT"
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/clojurescript "1.10.773"
+                  :exclusions [com.google.javascript/closure-compiler-unshaded
+                               org.clojure/google-closure-library
+                               org.clojure/google-closure-library-third-party]]
+                 [thheller/shadow-cljs "2.11.7"]
+                 [reagent "0.10.0"]
+                 [re-frame "1.1.2"]]
+
+  :plugins [[lein-shadow "0.3.1"]
+            
+            [lein-shell "0.5.0"]]
+
+  :min-lein-version "2.9.0"
+
+  :source-paths ["src/clj" "src/cljs"]
+
+  :test-paths   ["test/cljs"]
+
+  :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"
+                                    "test/js"]
+
+
+  :shadow-cljs {:nrepl {:port 8777}
+                
+                :builds {:app {:target :browser
+                               :output-dir "resources/public/js/compiled"
+                               :asset-path "/js/compiled"
+                               :modules {:app {:init-fn metafacture-playground.core/init
+                                               :preloads [devtools.preload]}}
+
+                               :devtools {:http-root "resources/public"
+                                          :http-port 8280
+                                          }}
+                         :browser-test
+                         {:target :browser-test
+                          :ns-regexp "-test$"
+                          :runner-ns shadow.test.browser
+                          :test-dir "target/browser-test"
+                          :devtools {:http-root "target/browser-test"
+                                     :http-port 8290}}
+
+                         :karma-test
+                         {:target :karma
+                          :ns-regexp "-test$"
+                          :output-to "target/karma-test.js"}}}
+  
+  :shell {:commands {"karma" {:windows         ["cmd" "/c" "karma"]
+                              :default-command "karma"}
+                     "open"  {:windows         ["cmd" "/c" "start"]
+                              :macosx          "open"
+                              :linux           "xdg-open"}}}
+
+  :aliases {"dev"          ["do" 
+                            ["shell" "echo" "\"DEPRECATED: Please use lein watch instead.\""]
+                            ["watch"]]
+            "watch"        ["with-profile" "dev" "do"
+                            ["shadow" "watch" "app" "browser-test" "karma-test"]]
+
+            "prod"         ["do"
+                            ["shell" "echo" "\"DEPRECATED: Please use lein release instead.\""]
+                            ["release"]]
+
+            "release"      ["with-profile" "prod" "do"
+                            ["shadow" "release" "app"]]
+
+            "build-report" ["with-profile" "prod" "do"
+                            ["shadow" "run" "shadow.cljs.build-report" "app" "target/build-report.html"]
+                            ["shell" "open" "target/build-report.html"]]
+
+            "karma"        ["do"
+                            ["shell" "echo" "\"DEPRECATED: Please use lein ci instead.\""]
+                            ["ci"]]
+            "ci"           ["with-profile" "prod" "do"
+                            ["shadow" "compile" "karma-test"]
+                            ["shell" "karma" "start" "--single-run" "--reporters" "junit,dots"]]}
+
+  :profiles
+  {:dev
+   {:dependencies [[binaryage/devtools "1.0.2"]]
+    :source-paths ["dev"]}
+
+   :prod {}
+   
+}
+
+  :prep-tasks [])

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>metafacture-playground</title>
+  </head>
+  <body>
+    <noscript>
+      metafacture-playground is a JavaScript app. Please enable JavaScript to continue.
+    </noscript>
+    <div id="app"></div>
+    <script src="js/compiled/app.js"></script>
+  </body>
+</html>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -2,8 +2,10 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title>metafacture-playground</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Metafacture Playground</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="style.css"/>
   </head>
   <body>
     <noscript>
@@ -11,5 +13,10 @@
     </noscript>
     <div id="app"></div>
     <script src="js/compiled/app.js"></script>
+        <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
   </body>
 </html>

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -1,0 +1,83 @@
+body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    font: 16px Helvetica,sans-serif;
+}
+
+a {
+    color: #22a;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+.container {
+    display: block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    margin: 20px;
+}
+
+.header {
+    display: block;
+    position: absolute;
+    background-color: #e8e8e8;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 60px;
+    padding: 10px;
+}
+
+.content {
+    display: block;
+    position: absolute;
+    top: 90px;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+}
+
+#xtext-editor {
+    display: block;
+    position: absolute;
+    top: 10em;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 4px;
+    border: 1px solid #aaa;
+    width: 50%;
+    height: 70%;
+}
+
+#data {
+    width: 100%;
+    margin-bottom: 5px;
+}
+
+#flux {
+    width: 100%;
+}
+
+.row {
+    display: flex;
+}
+
+.col {
+    flex: 50%;
+}
+
+#result {
+    padding: 15px;
+    margin: 15px;
+    white-space: pre-wrap;
+    text-align: left;
+    width: 100%;
+}

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -14,69 +14,28 @@ a:hover {
     text-decoration: underline;
 }
 
+.simple-button {
+    margin-right: 5px;
+    margin-bottom: 5px;
+}
+
 .container {
     display: block;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
     margin: 20px;
 }
 
 .header {
-    display: block;
-    position: absolute;
     background-color: #e8e8e8;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 60px;
-    padding: 10px;
 }
 
-.content {
-    display: block;
-    position: absolute;
-    top: 90px;
-    bottom: 0;
-    left: 0;
+.simple-input {
     width: 100%;
 }
 
-#xtext-editor {
-    display: block;
-    position: absolute;
-    top: 10em;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    padding: 4px;
-    border: 1px solid #aaa;
-    width: 50%;
-    height: 70%;
-}
-
-#data {
-    width: 100%;
-    margin-bottom: 5px;
-}
-
-#flux {
-    width: 100%;
-}
-
-.row {
-    display: flex;
-}
-
-.col {
-    flex: 50%;
-}
-
-#result {
+textarea {
     padding: 15px;
     margin: 15px;
+    margin-left: 0;
     white-space: pre-wrap;
     text-align: left;
     width: 100%;

--- a/resources/public/style.css
+++ b/resources/public/style.css
@@ -40,3 +40,22 @@ textarea {
     text-align: left;
     width: 100%;
 }
+
+.loader {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    border: 16px solid #f3f3f3; /* Light grey */
+    border-top: 16px solid #3498db; /* Blue */
+    border-radius: 50%;
+    width: 120px;
+    height: 120px;
+    z-index: 1;
+    margin: -76px 0 0 -76px;
+    animation: spin 2s linear infinite;
+  }
+
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }

--- a/src/clj/metafacture_playground/handler.clj
+++ b/src/clj/metafacture_playground/handler.clj
@@ -4,7 +4,7 @@
    [compojure.route :refer [resources not-found]]
    [compojure.handler :refer [api] :rename {api compojure-api}]
    [metafacture-playground.process :refer [process]]
-   [ring.util.response :refer [resource-response]]
+   [ring.util.response :refer [resource-response header response content-type]]
    [ring.middleware.reload :refer [wrap-reload]]
    [ring.middleware.params :refer [wrap-params]]
    [shadow.http.push-state :as push-state]))
@@ -12,7 +12,11 @@
 (defroutes routes
   (GET "/" [] (resource-response "index.html" {:root "public"}))
   (GET "/process" [data flux fix]
-     (str (process data flux fix)))
+     (-> (process data flux fix)
+         (str)
+         (response)
+         (header "Access-Control-Allow-Origin" "*")
+         (content-type "text/plain")))
   (resources "/")
   (not-found "Page not found"))
 

--- a/src/clj/metafacture_playground/handler.clj
+++ b/src/clj/metafacture_playground/handler.clj
@@ -1,16 +1,21 @@
 (ns metafacture-playground.handler
   (:require
-    [compojure.core :refer [GET defroutes]]
-    [compojure.route :refer [resources not-found]]
-    [ring.util.response :refer [resource-response]]
-    [ring.middleware.reload :refer [wrap-reload]]
-    [shadow.http.push-state :as push-state]))
+   [compojure.core :refer [GET defroutes]]
+   [compojure.route :refer [resources not-found]]
+   [compojure.handler :refer [api] :rename {api compojure-api}]
+   [metafacture-playground.process :refer [process]]
+   [ring.util.response :refer [resource-response]]
+   [ring.middleware.reload :refer [wrap-reload]]
+   [ring.middleware.params :refer [wrap-params]]
+   [shadow.http.push-state :as push-state]))
 
 (defroutes routes
   (GET "/" [] (resource-response "index.html" {:root "public"}))
+  (GET "/process" [data flux fix]
+     (str (process data flux fix)))
   (resources "/")
   (not-found "Page not found"))
 
 (def dev-handler (-> #'routes wrap-reload push-state/handle))
 
-(def handler routes)
+(def handler (wrap-params routes))

--- a/src/clj/metafacture_playground/handler.clj
+++ b/src/clj/metafacture_playground/handler.clj
@@ -1,0 +1,16 @@
+(ns metafacture-playground.handler
+  (:require
+    [compojure.core :refer [GET defroutes]]
+    [compojure.route :refer [resources not-found]]
+    [ring.util.response :refer [resource-response]]
+    [ring.middleware.reload :refer [wrap-reload]]
+    [shadow.http.push-state :as push-state]))
+
+(defroutes routes
+  (GET "/" [] (resource-response "index.html" {:root "public"}))
+  (resources "/")
+  (not-found "Page not found"))
+
+(def dev-handler (-> #'routes wrap-reload push-state/handle))
+
+(def handler routes)

--- a/src/clj/metafacture_playground/process.clj
+++ b/src/clj/metafacture_playground/process.clj
@@ -1,0 +1,71 @@
+(ns metafacture-playground.process
+  (:require
+   [clojure.java.io :as jio]
+   [clojure.string :as clj-str])
+  (:import
+   (java.io File)
+   (org.metafacture.runner Flux)))
+
+(defn- content->tempfile-path [content file-extension]
+  (let [temp-file (File/createTempFile "metafix" file-extension)]
+   (with-open [file (jio/writer temp-file)]
+     (binding [*out* file]
+       (print content)))
+    (.deleteOnExit temp-file)
+    (clj-str/replace (.getAbsolutePath temp-file) "\\" "/")))
+
+(defn- data->flux-content [data]
+  (if data
+    (str "\""
+         (content->tempfile-path data ".txt")
+         "\""
+         "|open-file|")
+    ""))
+
+(defn- fix->flux-content [fix]
+  (str
+   "|org.metafacture.metamorph.Metafix(\""
+   (content->tempfile-path fix ".fix")
+   "\")|"))
+
+(defn- flux->flux-content [flux fix]
+  (-> flux
+      (clj-str/replace "\\s?\\|\\s?" "|")
+      (clj-str/replace "|fix|" fix)))
+
+(defn- flux-output []
+  (let [temp-file-path (content->tempfile-path "" ".txt")]
+    [temp-file-path
+     (str
+      "|write(\""
+      temp-file-path
+      "\");")]))
+
+(defn- ->flux-content [data flux fix]
+  (let [fix (fix->flux-content fix)
+        [out-path output] (flux-output)]
+    [out-path
+     (str
+      (data->flux-content data)
+      (flux->flux-content flux fix)
+      output)]))
+
+(defn- process-flux [file-path out-path]
+  (try
+    (Flux/main (into-array [file-path]))
+    (println "Processed flux file.")
+    (slurp out-path)
+    (catch Exception e
+      (println "Something went wrong: " (.getMessage e))
+      (println "Exception: " (.printStackTrace e))
+      (str "Sorry, something went wrong: " (.getMessage e)))
+    (catch Error e
+      (println "Something really went wrong: " (.getMessage e))
+      (println "Error: " (.printStackTrace e))
+      (str "Sorry, something went wrong: " (.getMessage e)))))
+
+(defn process [data flux fix]
+  (let [[out-path flux-content] (->flux-content data flux fix)]
+       (-> flux-content
+           (content->tempfile-path ".flux")
+           (process-flux out-path))))

--- a/src/clj/metafacture_playground/server.clj
+++ b/src/clj/metafacture_playground/server.clj
@@ -6,4 +6,5 @@
 
  (defn -main [& _args]
    (let [port (or (env :port) 3000)]
+     (println "Start server with port " port)
      (run-jetty handler {:port port :join? false})))

--- a/src/clj/metafacture_playground/server.clj
+++ b/src/clj/metafacture_playground/server.clj
@@ -1,0 +1,9 @@
+(ns metafacture-playground.server
+  (:require [metafacture-playground.handler :refer [handler]]
+            [config.core :refer [env]]
+            [ring.adapter.jetty :refer [run-jetty]])
+  (:gen-class))
+
+ (defn -main [& _args]
+   (let [port (or (env :port) 3000)]
+     (run-jetty handler {:port port :join? false})))

--- a/src/cljs/deps.cljs
+++ b/src/cljs/deps.cljs
@@ -1,0 +1,5 @@
+{:npm-dev-deps {"shadow-cljs"           "2.11.7"
+                "karma"                 "5.2.3"
+                "karma-chrome-launcher" "3.1.0"
+                "karma-cljs-test"       "0.1.0"
+                "karma-junit-reporter"  "2.0.1"}}

--- a/src/cljs/metafacture_playground/config.cljs
+++ b/src/cljs/metafacture_playground/config.cljs
@@ -1,0 +1,4 @@
+(ns metafacture-playground.config)
+
+(def debug?
+  ^boolean goog.DEBUG)

--- a/src/cljs/metafacture_playground/core.cljs
+++ b/src/cljs/metafacture_playground/core.cljs
@@ -1,0 +1,24 @@
+(ns metafacture-playground.core
+  (:require
+   [reagent.dom :as rdom]
+   [re-frame.core :as re-frame]
+   [metafacture-playground.events :as events]
+   [metafacture-playground.views :as views]
+   [metafacture-playground.config :as config]
+   ))
+
+
+(defn dev-setup []
+  (when config/debug?
+    (println "dev mode")))
+
+(defn ^:dev/after-load mount-root []
+  (re-frame/clear-subscription-cache!)
+  (let [root-el (.getElementById js/document "app")]
+    (rdom/unmount-component-at-node root-el)
+    (rdom/render [views/main-panel] root-el)))
+
+(defn init []
+  (re-frame/dispatch-sync [::events/initialize-db])
+  (dev-setup)
+  (mount-root))

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -8,4 +8,5 @@
 (def default-db
   {:fields {:data ""
             :flux ""
-            :fix  ""}})
+            :fix  ""
+            :result "No result"}})

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -1,4 +1,6 @@
 (ns metafacture-playground.db)
 
 (def default-db
-  {:name "re-frame"})
+  {:fields {:data ""
+            :flux ""
+            :fix  ""}})

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -1,0 +1,4 @@
+(ns metafacture-playground.db)
+
+(def default-db
+  {:name "re-frame"})

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -6,7 +6,8 @@
    :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/\n"})
 
 (def default-db
-  {:fields {:data ""
-            :flux ""
-            :fix  ""
-            :result "No result"}})
+  {:input-fields {:data ""
+                  :flux ""
+                  :fix  ""}
+   :result {:loading? false
+            :content "No result"}})

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -1,5 +1,10 @@
 (ns metafacture-playground.db)
 
+(def sample-fields
+  {:data "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}\n 2{a: Räuber, b {n: Schiller, v: F}, c: Weimar}"
+   :flux "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"
+   :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/\n"})
+
 (def default-db
   {:fields {:data ""
             :flux ""

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -1,8 +1,7 @@
 (ns metafacture-playground.events
   (:require
    [re-frame.core :as re-frame]
-   [metafacture-playground.db :as db]
-   ))
+   [metafacture-playground.db :as db]))
 
 (re-frame/reg-event-db
    :edit
@@ -14,7 +13,7 @@
   (fn [db _]
     (assoc db :fields {:data "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}\n 2{a: Räuber, b {n: Schiller, v: F}, c: Weimar}"
                        :flux "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"
-                       :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/"})))
+                       :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/\n"})))
 
 (re-frame/reg-event-db
  :clear-all

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -1,21 +1,25 @@
 (ns metafacture-playground.events
   (:require
    [re-frame.core :as re-frame]
+   [day8.re-frame.http-fx]
+   [ajax.core :as ajax]
    [metafacture-playground.db :as db]))
 
+;; Editing input fields
+
 (defn edit-value
-  [db [_ path new-value]]
-  (assoc-in db path new-value))
+  [db [_ field-name new-value]]
+  (assoc-in db [:input-fields field-name] new-value))
 
 (re-frame/reg-event-db
- :edit
+ :edit-input-value
  edit-value)
 
 (defn load-sample
   [db _]
   (reduce
    (fn [db [k sample-v]]
-     (assoc-in db [:fields k] sample-v))
+     (assoc-in db [:input-fields k] sample-v))
    db
    db/sample-fields))
 
@@ -28,13 +32,54 @@
   (let [fields [:data :flux :fix]]
     (reduce
      (fn [db field-to-empty]
-       (assoc-in db [:fields field-to-empty] ""))
+       (assoc-in db [:input-fields field-to-empty] ""))
      db
      fields)))
 
 (re-frame/reg-event-db
  :clear-all
  clear-all)
+
+;; Processing
+
+(defn process-response
+  [db [_ response]]
+  (-> db
+      (assoc-in [:result :loading?] false)
+      (assoc-in [:result :content] response)))
+
+(re-frame/reg-event-db                   
+ :process-response             
+  process-response)
+
+(defn bad-response
+  [db [_ response]]
+  (-> db
+      (assoc-in [:result :loading?] false)
+      (assoc-in [:result :content] "Bad response")))
+
+(re-frame/reg-event-db
+ :bad-response
+ bad-response)
+
+(defn process
+  [{:keys [db]} [_ data flux fix]]
+  {:http-xhrio {:method          :get
+                :uri             "http://localhost:3000/process"
+                :params {:data data
+                         :flux flux
+                         :fix fix}
+                :format (ajax/json-request-format)
+                :response-format (ajax/text-response-format)
+                :on-success      [:process-response]
+                :on-failure      [:bad-response]}
+   :db  (assoc-in db [:result :loading?] true)})
+
+(re-frame/reg-event-fx
+ :process
+ process)
+
+;; Initialize-db
 
 (defn initialize-db
   [_ _]

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -13,9 +13,11 @@
 
 (defn load-sample
   [db _]
-  (assoc db
-         :fields
-         db/sample-fields))
+  (reduce
+   (fn [db [k sample-v]]
+     (assoc-in db [:fields k] sample-v))
+   db
+   db/sample-fields))
 
 (re-frame/reg-event-db
   :load-sample
@@ -23,9 +25,12 @@
 
 (defn clear-all
   [db _]
-  (assoc db :fields {:data ""
-                     :flux ""
-                     :fix  ""}))
+  (let [fields [:data :flux :fix]]
+    (reduce
+     (fn [db field-to-empty]
+       (assoc-in db [:fields field-to-empty] ""))
+     db
+     fields)))
 
 (re-frame/reg-event-db
  :clear-all

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -3,26 +3,38 @@
    [re-frame.core :as re-frame]
    [metafacture-playground.db :as db]))
 
+(defn edit-value
+  [db [_ path new-value]]
+  (assoc-in db path new-value))
+
 (re-frame/reg-event-db
-   :edit
-   (fn [db [_ path new-value]]
-     (assoc-in db path new-value)))
+ :edit
+ edit-value)
+
+(defn load-sample
+  [db _]
+  (assoc db
+         :fields
+         db/sample-fields))
 
 (re-frame/reg-event-db
   :load-sample
-  (fn [db _]
-    (assoc db :fields {:data "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}\n 2{a: Räuber, b {n: Schiller, v: F}, c: Weimar}"
-                       :flux "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"
-                       :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/\n"})))
+  load-sample)
+
+(defn clear-all
+  [db _]
+  (assoc db :fields {:data ""
+                     :flux ""
+                     :fix  ""}))
 
 (re-frame/reg-event-db
  :clear-all
- (fn [db _]
-   (assoc db :fields {:data ""
-                      :flux ""
-                      :fix ""})))
+ clear-all)
+
+(defn initialize-db
+  [_ _]
+  db/default-db)
 
 (re-frame/reg-event-db
  ::initialize-db
- (fn [_ _]
-   db/default-db))
+ initialize-db)

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -1,0 +1,10 @@
+(ns metafacture-playground.events
+  (:require
+   [re-frame.core :as re-frame]
+   [metafacture-playground.db :as db]
+   ))
+
+(re-frame/reg-event-db
+ ::initialize-db
+ (fn [_ _]
+   db/default-db))

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -5,6 +5,25 @@
    ))
 
 (re-frame/reg-event-db
+   :edit
+   (fn [db [_ path new-value]]
+     (assoc-in db path new-value)))
+
+(re-frame/reg-event-db
+  :load-sample
+  (fn [db _]
+    (assoc db :fields {:data "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}\n 2{a: Räuber, b {n: Schiller, v: F}, c: Weimar}"
+                       :flux "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"
+                       :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/"})))
+
+(re-frame/reg-event-db
+ :clear-all
+ (fn [db _]
+   (assoc db :fields {:data ""
+                      :flux ""
+                      :fix ""})))
+
+(re-frame/reg-event-db
  ::initialize-db
  (fn [_ _]
    db/default-db))

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -65,7 +65,7 @@
 (defn process
   [{:keys [db]} [_ data flux fix]]
   {:http-xhrio {:method          :get
-                :uri             "http://localhost:3000/process"
+                :uri             "process"
                 :params {:data data
                          :flux flux
                          :fix fix}

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -3,6 +3,6 @@
    [re-frame.core :as re-frame]))
 
 (re-frame/reg-sub
- ::name
- (fn [db]
-   (:name db)))
+  ::field-value
+  (fn [db [_ path-to-field]]
+    (get-in db path-to-field)))

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -4,5 +4,15 @@
 
 (re-frame/reg-sub
   ::field-value
-  (fn [db [_ path-to-field]]
-    (get-in db path-to-field)))
+  (fn [db [_ field-name]]
+    (get-in db [:input-fields field-name])))
+
+(re-frame/reg-sub
+ ::process-result
+ (fn [db _]
+   (get-in db [:result :content])))
+
+(re-frame/reg-sub
+ ::result-loading?
+ (fn [db _]
+   (get-in db [:result :loading?])))

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -1,0 +1,8 @@
+(ns metafacture-playground.subs
+  (:require
+   [re-frame.core :as re-frame]))
+
+(re-frame/reg-sub
+ ::name
+ (fn [db]
+   (:name db)))

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -5,7 +5,7 @@
    [clojure.string :as clj-str]))
 
 (defn control-panel []
-  [:div
+  [:div.row
    [:input {:type "button"
             :value "Load sample"
             :on-click #(re-frame/dispatch [:load-sample])}]
@@ -16,7 +16,7 @@
 (defn field-row [field-name]
   (let [field-value(re-frame/subscribe [::subs/field-value [:fields field-name]])]
     (fn [field-name]
-      [:div (str (-> field-name name clj-str/capitalize) ": ")
+      [:div.row (str (-> field-name name clj-str/capitalize) ": ")
        [:input {:type "text"
                 :id (name field-name)
                 :value @field-value
@@ -25,15 +25,22 @@
 (defn editor []
   (let [fix  (re-frame/subscribe [::subs/field-value [:fields :fix]])]
     (fn []
-      [:div "Fix:"
+      [:div.col "Fix:"
        [:textarea {:id "fix"
                    :value @fix
                    :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
 
+(defn result-panel []
+  [:div.col
+   [:input {:id "result"
+            :value "This could be your result"}]])
+
 (defn main-panel []
-  [:div
+  [:div.container
    [:h1 "Metafacture Playground"]
    [control-panel]
    [field-row :data]
    [field-row :flux]
-   [editor]])
+   [:div.row
+    [editor]
+    [result-panel]]])

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -4,6 +4,11 @@
    [metafacture-playground.subs :as subs]
    [clojure.string :as clj-str]))
 
+(defn header []
+  [:div.row
+   [:div.col
+    [:h1.header  "Metafacture Playground"]]])
+
 (defn control-panel []
   [:div.row
    [:div.col
@@ -44,9 +49,7 @@
 
 (defn main-panel []
   [:div.container
-   [:div.row
-    [:div.col
-     [:h1.header  "Metafacture Playground"]]]
+   [header]
    [control-panel]
    [field-row :data]
    [field-row :flux]

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -6,38 +6,47 @@
 
 (defn control-panel []
   [:div.row
-   [:input {:type "button"
-            :value "Load sample"
-            :on-click #(re-frame/dispatch [:load-sample])}]
-   [:input {:type "button"
-            :value "Clear all"
-            :on-click #(re-frame/dispatch [:clear-all])}]])
+   [:div.col
+    [:input.simple-button {:type "button"
+                           :value "Load sample"
+                           :on-click #(re-frame/dispatch [:load-sample])}]
+    [:input.simple-button {:type "button"
+                           :value "Clear all"
+                           :on-click #(re-frame/dispatch [:clear-all])}]]])
 
 (defn field-row [field-name]
-  (let [field-value(re-frame/subscribe [::subs/field-value [:fields field-name]])]
+  (let [field-value (re-frame/subscribe [::subs/field-value [:fields field-name]])]
     (fn [field-name]
-      [:div.row (str (-> field-name name clj-str/capitalize) ": ")
-       [:input {:type "text"
-                :id (name field-name)
-                :value @field-value
-                :on-change #(re-frame/dispatch [:edit [:fields field-name] (-> % .-target .-value)])}]])))
+      [:div.row
+       [:div.col-1
+        [:p (str (-> field-name name clj-str/capitalize) ": ")]]
+       [:div.col
+        [:input.simple-input {:type "text"
+                              :id (name field-name)
+                              :value @field-value
+                              :on-change #(re-frame/dispatch [:edit [:fields field-name] (-> % .-target .-value)])}]]])))
 
 (defn editor []
   (let [fix  (re-frame/subscribe [::subs/field-value [:fields :fix]])]
     (fn []
-      [:div.col "Fix:"
-       [:textarea {:id "fix"
+      [:div.col
+       [:textarea {:id "editor"
                    :value @fix
+                   :rows 25
+                   :cols 40
                    :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
 
 (defn result-panel []
   [:div.col
-   [:input {:id "result"
-            :value "This could be your result"}]])
+   [:textarea {:id "result"
+               :rows 25
+               :cols 40}]])
 
 (defn main-panel []
   [:div.container
-   [:h1 "Metafacture Playground"]
+   [:div.row
+    [:div.col
+     [:h1.header  "Metafacture Playground"]]]
    [control-panel]
    [field-row :data]
    [field-row :flux]

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -1,0 +1,11 @@
+(ns metafacture-playground.views
+  (:require
+   [re-frame.core :as re-frame]
+   [metafacture-playground.subs :as subs]
+   ))
+
+(defn main-panel []
+  (let [name (re-frame/subscribe [::subs/name])]
+    [:div
+     [:h1 "Hello from " @name]
+     ]))

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -42,10 +42,14 @@
                    :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
 
 (defn result-panel []
-  [:div.col
-   [:textarea {:id "result"
-               :rows 25
-               :cols 40}]])
+  (let [result (re-frame/subscribe [::subs/field-value [:fields :result]])]
+    (fn []
+      [:div.col
+       [:textarea {:id "result"
+                   :value @result
+                   :rows 25
+                   :cols 40
+                   :readOnly true}]])))
 
 (defn main-panel []
   [:div.container

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -2,10 +2,38 @@
   (:require
    [re-frame.core :as re-frame]
    [metafacture-playground.subs :as subs]
-   ))
+   [clojure.string :as clj-str]))
+
+(defn field-row [field-name]
+  (let [field-value(re-frame/subscribe [::subs/field-value [:fields field-name]])]
+    (fn [field-name]
+      [:div (str (-> field-name name clj-str/capitalize) ": ")
+       [:input {:type "text"
+                :id (name field-name)
+                :value @field-value
+                :on-change #(re-frame/dispatch [:edit [:fields field-name] (-> % .-target .-value)])}]])))
+
+(defn editor []
+  (let [fix  (re-frame/subscribe [::subs/field-value [:fields :fix]])]
+    (fn []
+      [:div "Fix:"
+       [:textarea {:id "fix"
+                   :value @fix
+                   :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
+
+(defn control-panel []
+  [:div
+   [:input {:type "button"
+            :value "Load sample"
+            :on-click #(re-frame/dispatch [:load-sample])}]
+   [:input {:type "button"
+            :value "Clear all"
+            :on-click #(re-frame/dispatch [:clear-all])}]])
 
 (defn main-panel []
-  (let [name (re-frame/subscribe [::subs/name])]
-    [:div
-     [:h1 "Hello from " @name]
-     ]))
+  [:div
+   [:h1 "Metafacture Playground"]
+   [control-panel]
+   [field-row :data]
+   [field-row :flux]
+   [editor]])

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -4,6 +4,15 @@
    [metafacture-playground.subs :as subs]
    [clojure.string :as clj-str]))
 
+(defn control-panel []
+  [:div
+   [:input {:type "button"
+            :value "Load sample"
+            :on-click #(re-frame/dispatch [:load-sample])}]
+   [:input {:type "button"
+            :value "Clear all"
+            :on-click #(re-frame/dispatch [:clear-all])}]])
+
 (defn field-row [field-name]
   (let [field-value(re-frame/subscribe [::subs/field-value [:fields field-name]])]
     (fn [field-name]
@@ -20,15 +29,6 @@
        [:textarea {:id "fix"
                    :value @fix
                    :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
-
-(defn control-panel []
-  [:div
-   [:input {:type "button"
-            :value "Load sample"
-            :on-click #(re-frame/dispatch [:load-sample])}]
-   [:input {:type "button"
-            :value "Clear all"
-            :on-click #(re-frame/dispatch [:clear-all])}]])
 
 (defn main-panel []
   [:div

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -9,6 +9,15 @@
    [:div.col
     [:h1.header  "Metafacture Playground"]]])
 
+(defn process-button []
+  (let [data (re-frame/subscribe [::subs/field-value :data])
+        flux (re-frame/subscribe [::subs/field-value :flux])
+        fix  (re-frame/subscribe [::subs/field-value :fix])]
+    (fn []
+      [:input.simple-button {:type "button"
+                             :value "Process"
+                             :on-click #(re-frame/dispatch [:process @data @flux @fix])}])))
+
 (defn control-panel []
   [:div.row
    [:div.col
@@ -17,10 +26,11 @@
                            :on-click #(re-frame/dispatch [:load-sample])}]
     [:input.simple-button {:type "button"
                            :value "Clear all"
-                           :on-click #(re-frame/dispatch [:clear-all])}]]])
+                           :on-click #(re-frame/dispatch [:clear-all])}]
+    [process-button]]])
 
 (defn field-row [field-name]
-  (let [field-value (re-frame/subscribe [::subs/field-value [:fields field-name]])]
+  (let [field-value (re-frame/subscribe [::subs/field-value field-name])]
     (fn [field-name]
       [:div.row
        [:div.col-1
@@ -29,27 +39,30 @@
         [:input.simple-input {:type "text"
                               :id (name field-name)
                               :value @field-value
-                              :on-change #(re-frame/dispatch [:edit [:fields field-name] (-> % .-target .-value)])}]]])))
+                              :on-change #(re-frame/dispatch [:edit-input-value field-name (-> % .-target .-value)])}]]])))
 
 (defn editor []
-  (let [fix  (re-frame/subscribe [::subs/field-value [:fields :fix]])]
+  (let [fix  (re-frame/subscribe [::subs/field-value :fix])]
     (fn []
       [:div.col
        [:textarea {:id "editor"
                    :value @fix
                    :rows 25
                    :cols 40
-                   :on-change #(re-frame/dispatch [:edit [:fields :fix] (-> % .-target .-value)])}]])))
+                   :on-change #(re-frame/dispatch [:edit-input-value :fix (-> % .-target .-value)])}]])))
 
 (defn result-panel []
-  (let [result (re-frame/subscribe [::subs/field-value [:fields :result]])]
+  (let [result (re-frame/subscribe [::subs/process-result])
+        loading? (re-frame/subscribe [::subs/result-loading?])]
     (fn []
       [:div.col
-       [:textarea {:id "result"
-                   :value @result
-                   :rows 25
-                   :cols 40
-                   :readOnly true}]])))
+       (if @loading?
+         [:div.loader]
+         [:textarea {:id "result"
+                     :value @result
+                     :rows 25
+                     :cols 40
+                     :readOnly true}])])))
 
 (defn main-panel []
   [:div.container

--- a/test/clj/metafacture_playground/process_test.clj
+++ b/test/clj/metafacture_playground/process_test.clj
@@ -1,0 +1,29 @@
+(ns metafacture-playground.process-test
+  (:require [clojure.test :refer :all]
+            [metafacture-playground.process :refer [process]]))
+
+(def sample-data {:data "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}\n 2{a: Räuber, b {n: Schiller, v: F}, c: Weimar}"
+                  :flux "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"
+                  :fix  "map(_id, id)\nmap(a,title)\nmap(b.n,author)\n/*map(_else)*/\n"
+                  :result (str "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                               "\n<collection>"
+                               "\n"
+                               "\n	<record>"
+                               "\n		<id>1</id>"
+                               "\n		<title>Faust</title>"
+                               "\n		<author>Goethe</author>"
+                               "\n	</record>"
+                               "\n"
+                               "\n	<record>"
+                               "\n		<id>2</id>"
+                               "\n		<title>Räuber</title>"
+                               "\n		<author>Schiller</author>"
+                               "\n	</record>"
+                               "\n"
+                               "\n</collection>\n")})
+
+(deftest processing-test
+  (testing "Process sample data correctly."
+    (let [result (process (:data sample-data) (:flux sample-data) (:fix sample-data))]
+      (is (= result (:result sample-data))))))
+

--- a/test/cljs/metafacture_playground/core_test.cljs
+++ b/test/cljs/metafacture_playground/core_test.cljs
@@ -1,0 +1,7 @@
+(ns metafacture-playground.core-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [metafacture-playground.core :as core]))
+
+(deftest fake-test
+  (testing "fake description"
+    (is (= 1 2))))

--- a/test/cljs/metafacture_playground/core_test.cljs
+++ b/test/cljs/metafacture_playground/core_test.cljs
@@ -1,7 +1,0 @@
-(ns metafacture-playground.core-test
-  (:require [cljs.test :refer-macros [deftest testing is]]
-            [metafacture-playground.core :as core]))
-
-(deftest fake-test
-  (testing "fake description"
-    (is (= 1 2))))

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -1,0 +1,60 @@
+(ns metafacture-playground.event-handler-test
+  (:require [cljs.test :refer-macros [deftest testing is]]
+            [metafacture-playground.db :as db]
+            [metafacture-playground.events :as events]))
+
+; Initilized db = empty db
+(def empty-db
+  (events/initialize-db {} [::events/initialize-db]))
+
+; db with one field not empty
+(def db1
+  (events/edit-value empty-db [:edit [:fields :data] "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}"]))
+
+; db with no empty fields
+(def db2
+  (-> empty-db
+      (events/edit-value [:edit [:fields :data] "1{a: Faust, b {n: Goethe, v: JW}, c: Weimar}"])
+      (events/edit-value [:edit [:fields :flux] "as-lines|decode-formeta|fix|stream-to-xml(rootTag=\"collection\")"])
+      (events/edit-value [:edit [:fields :fix] "map(_id, id)\nmap(a,title)\nmap(b.n,author)"])))
+
+(def db-with-sample
+  {:fields db/sample-fields})
+
+
+(deftest edit-value-test
+  (testing "Test editing values."
+    (let [new-value "I am a new value"
+          path [:fields :fix]
+          db' (events/edit-value empty-db [:edit path new-value])]
+      (is (and (not= db' empty-db)
+               (= (get-in db' path)
+                  new-value))))))
+
+
+(deftest load-sample-test
+  (testing "Test loading sample with all fields empty."
+    (let [db'    (events/load-sample empty-db :load-sample)]
+      (is db' db-with-sample)))
+
+  (testing "Test loading sample with part of fields not empty."
+    (let [db'    (events/load-sample db1 :load-sample)]
+      (is (= db' db-with-sample))))
+
+  (testing "Test loading sample with all fields not empty."
+    (let [db' (events/load-sample db2 :load-sample)]
+      (is (= db' db-with-sample)))))
+
+
+(deftest clear-all-test
+  (testing "Test clear all fields with all fields already empty."
+    (let [db' (events/clear-all empty-db :clear-all)]
+      (is (= db' empty-db))))
+
+  (testing "Test clear all fields with part of fields not empty."
+    (let [db' (events/clear-all db1 :clear-all)]
+      (is (= db' empty-db))))
+
+  (testing "Test clear all fields with all fields not empty."
+    (let [db' (events/clear-all db2 :clear-all)]
+      (is (= db' empty-db)))))  

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -26,7 +26,9 @@
   (testing "Test editing values."
     (let [new-value "I am a new value"
           path [:fields :fix]
-          db' (events/edit-value empty-db [:edit path new-value])]
+          db' (-> empty-db 
+                  (events/edit-value [:edit path new-value])
+                  (update :fields dissoc :result))]
       (is (and (not= db' empty-db)
                (= (get-in db' path)
                   new-value))))))
@@ -34,15 +36,21 @@
 
 (deftest load-sample-test
   (testing "Test loading sample with all fields empty."
-    (let [db'    (events/load-sample empty-db :load-sample)]
+    (let [db'    (-> empty-db
+                     (events/load-sample :load-sample)
+                     (update :fields dissoc :result))]
       (is db' db-with-sample)))
 
   (testing "Test loading sample with part of fields not empty."
-    (let [db'    (events/load-sample db1 :load-sample)]
+    (let [db'    (-> db1
+                     (events/load-sample :load-sample)
+                     (update :fields dissoc :result))]
       (is (= db' db-with-sample))))
 
   (testing "Test loading sample with all fields not empty."
-    (let [db' (events/load-sample db2 :load-sample)]
+    (let [db' (-> db2
+                  (events/load-sample :load-sample)
+                  (update :fields dissoc :result))]
       (is (= db' db-with-sample)))))
 
 

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -69,7 +69,7 @@
  (deftest process-button-test
    (testing "Test status after processing response"
      (let [db' (-> empty-db
-                   (events/load-sample))
+                   (events/load-sample db/sample-fields))
            {:keys [fix flux data]} (get db' :input-fields)
-           db'' (:db (events/process {:db db'} data flux fix))]
+           db'' (:db (events/process {:db db'} [:process data flux fix]))]
        (is (get-in db'' [:result  :loading?])))))


### PR DESCRIPTION
Adds inital Metafacture playground backend and frontend.
Replicate all functionalities of [org.metafacture.fix.web](https://github.com/metafacture/metafacture-fix/tree/master/org.metafacture.fix.web) project.

See https://github.com/metafacture/metafacture-playground/issues/1