### PR TITLE
Code refactoring

### DIFF
--- a/src/cljs/metafacture_playground/effects.cljs
+++ b/src/cljs/metafacture_playground/effects.cljs
@@ -2,7 +2,7 @@
   (:require [re-frame.core :as re-frame]))
 
 (re-frame/reg-fx
- :copy-to-clipboard
+ ::copy-to-clipboard
  (fn [val]
    (let [el (js/document.createElement "textarea")]
      (set! (.-value el) val)

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -145,8 +145,7 @@
 
 (defn initialize-db
   [_ [_ href]]
-  (let [url (assoc (uri href) :query nil)
-        {:keys [data flux fix process]} (-> href uri :query query-string->map)]
+  (let [{:keys [data flux fix process]} (-> href uri :query query-string->map)]
     (merge
      {:db (cond-> db/default-db
             data (assoc-in [:input-fields :data :content] data)

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -5,7 +5,7 @@
    [ajax.core :as ajax]
    [lambdaisland.uri :refer [uri join assoc-query* query-string->map]]
    [metafacture-playground.db :as db]
-   [metafacture-playground.effects]))
+   [metafacture-playground.effects :as effects]))
 
 ;;; Collapsing panels
 
@@ -26,7 +26,7 @@
   (assoc-in db [:input-fields field-name :content] new-value))
 
 (re-frame/reg-event-db
- :edit-input-value
+ ::edit-input-value
  edit-value)
 
 (defn update-cursor-position
@@ -34,7 +34,7 @@
   (assoc-in db [:input-fields field-name :cursor-position] cursor-position))
 
 (re-frame/reg-event-db
- :update-cursor-position
+ ::update-cursor-position
  update-cursor-position)
 
 (defn load-sample
@@ -46,7 +46,7 @@
    db/sample-fields))
 
 (re-frame/reg-event-db
-  :load-sample
+  ::load-sample
   load-sample)
 
 (defn clear-all
@@ -64,7 +64,7 @@
      paths)))
 
 (re-frame/reg-event-db
- :clear-all
+ ::clear-all
  clear-all)
 
 ;;; Copy to clipboard
@@ -72,10 +72,10 @@
 (defn copy-link
   [{:keys [db]} [_ val]]
   {:db db
-   :copy-to-clipboard val})
+   ::effects/copy-to-clipboard val})
 
 (re-frame/reg-event-fx
- :copy-link
+ ::copy-link
  copy-link)
 
 ;;; Share links
@@ -99,7 +99,7 @@
         (assoc-in [:links :workflow] nil))))
 
 (re-frame/reg-event-db
- :generate-links
+ ::generate-links
  generate-links)
 
 ;;; Processing
@@ -111,7 +111,7 @@
       (assoc-in [:result :content] response)))
 
 (re-frame/reg-event-db                   
- :process-response             
+ ::process-response
   process-response)
 
 (defn bad-response
@@ -121,7 +121,7 @@
       (assoc-in [:result :content] "Bad response")))
 
 (re-frame/reg-event-db
- :bad-response
+ ::bad-response
  bad-response)
 
 (defn process
@@ -133,12 +133,12 @@
                          :fix fix}
                 :format (ajax/json-request-format)
                 :response-format (ajax/text-response-format)
-                :on-success      [:process-response]
-                :on-failure      [:bad-response]}
+                :on-success      [::process-response]
+                :on-failure      [::bad-response]}
    :db (assoc-in db [:result :loading?] true)})
 
 (re-frame/reg-event-fx
- :process
+ ::process
  process)
 
 ;;; Initialize-db
@@ -152,7 +152,7 @@
             data (assoc-in [:input-fields :data :content] data)
             flux (assoc-in [:input-fields :flux :content] flux)
             fix (assoc-in [:input-fields :fix :content] fix))}
-     (when process {:dispatch [:process url data flux fix]}))))
+     (when process {:dispatch [::process data flux fix]}))))
 
 (re-frame/reg-event-fx
  ::initialize-db

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -16,7 +16,7 @@
             (not status)))
 
   (re-frame/reg-event-db
-   :collapse-panel
+   ::collapse-panel
    collapse-panel)
 
 ;;; Editing input fields

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -76,17 +76,16 @@
 
 (defn collapse-label [panel-path]
   (let [collapsed? (re-frame/subscribe [::subs/collapsed? panel-path])]
-    (fn [_]
-      [:> label
-       {:attached "top right"
-        :on-click #(re-frame/dispatch [:collapse-panel panel-path @collapsed?])}
-       [:> icon
-        {:name
-         (if @collapsed?
-           "chevron down"
-           "chevron up")
-         :style {:margin 0}
-         :size "large"}]])))
+    [:> label
+     {:attached "top right"
+      :on-click #(re-frame/dispatch [:collapse-panel panel-path @collapsed?])}
+     [:> icon
+      {:name
+       (if @collapsed?
+         "chevron down"
+         "chevron up")
+       :style {:margin 0}
+       :size "large"}]]))
 
 (defn screenreader-label [name for]
   [:label {:style {:position "absolute"
@@ -121,29 +120,27 @@
   (let [data (re-frame/subscribe [::subs/field-value :data])
         flux (re-frame/subscribe [::subs/field-value :flux])
         fix  (re-frame/subscribe [::subs/field-value :fix])]
-    (fn []
-      (simple-button {:content "Process"
-                      :dispatch-fn [:process @data @flux @fix]
-                      :icon-name "play"}))))
+    [simple-button {:content "Process"
+                    :dispatch-fn [:process @data @flux @fix]
+                    :icon-name "play"}]))
 
 (defn share-link [link-type label-text]
   (let [link (re-frame/subscribe [::subs/link link-type])]
-    (fn [link-type label-text]
-      [:> form-field
-       [:> label
-        {:id (str link-type "link-label")
-         :color color
-         :content label-text}]
-       [:> input
-        {:id (str link-type "-link-input")
-         :action {:color color
-                  :icon "copy"
-                  :on-click #(re-frame/dispatch [:copy-link @link])
-                  :alt "Copy link"
-                  :disabled (not @link)}
-         :placeholder (if-not @link "Nothing to share..." "")
-         :default-value (or @link "")
-         :readOnly true}]])))
+    [:> form-field
+     [:> label
+      {:id (str link-type "link-label")
+       :color color
+       :content label-text}]
+     [:> input
+      {:id (str link-type "-link-input")
+       :action {:color color
+                :icon "copy"
+                :on-click #(re-frame/dispatch [:copy-link @link])
+                :alt "Copy link"
+                :disabled (not @link)}
+       :placeholder (if-not @link "Nothing to share..." "")
+       :default-value (or @link "")
+       :readOnly true}]]))
 
 (defn share-links []
   [:> form
@@ -155,13 +152,12 @@
         data (re-frame/subscribe [::subs/field-value :data])
         flux (re-frame/subscribe [::subs/field-value :flux])
         fix (re-frame/subscribe [::subs/field-value :fix])]
-    (fn []
-      [:> popup
-       {:children (reagent/as-element [share-links])
-        :on "click"
-        :position "bottom left"
-        :wide "very"
-        :trigger (reagent/as-element (simple-button {:content "Share" :icon-name "share alternate" :dispatch-fn [:generate-links uri @data @flux @fix]}))}])))
+    [:> popup
+     {:children (reagent/as-element [share-links])
+      :on "click"
+      :position "bottom left"
+      :wide "very"
+      :trigger (reagent/as-element (simple-button {:content "Share" :icon-name "share alternate" :dispatch-fn [:generate-links uri @data @flux @fix]}))}]))
 
 (defn control-panel []
   [:> segment {:raised true}
@@ -201,14 +197,13 @@
 (defn editor-panel [config]
   (let [path [:input-fields (-> config :name keyword)]
         collapsed? (re-frame/subscribe [::subs/collapsed? path])]
-    (fn [config]
-      [:> grid-column {:width (:width config)}
-       [:> segment {:raised true}
-        [title-label (:name config)]
-        [collapse-label path]
-        [:> divider {:style {:margin "1.5rem 0 0.5rem 0"}}]
-        (when-not @collapsed?
-          [editor config])]])))
+    [:> grid-column {:width (:width config)}
+     [:> segment {:raised true}
+      [title-label (:name config)]
+      [collapse-label path]
+      [:> divider {:style {:margin "1.5rem 0 0.5rem 0"}}]
+      (when-not @collapsed?
+        [editor config])]]))
 
 ;;; Result field
 
@@ -216,22 +211,21 @@
   (let [content (re-frame/subscribe [::subs/process-result])
         loading? (re-frame/subscribe [::subs/result-loading?])
         collapsed? (re-frame/subscribe [::subs/collapsed? [:result]])]
-    (fn []
-      (when-not @collapsed?
-        (if @loading?
-          [:> segment {:basic true}
-           [:> loader {:active true
-                       :style {:padding "1.5rem"}}]]
+    (when-not @collapsed?
+      (if @loading?
+        [:> segment {:basic true}
+         [:> loader {:active true
+                     :style {:padding "1.5rem"}}]]
 
-          [:> form
-           [screenreader-label "Result" "result-panel"]
-           [:> textarea {:id "result-panel"
-                         :placeholder "No result"
-                         :value (or @content "")
-                         :rows (count (clj-str/split-lines @content))
-                         :fluid "true"
-                         :style {:border "none"}
-                         :readOnly true}]])))))
+        [:> form
+         [screenreader-label "Result" "result-panel"]
+         [:> textarea {:id "result-panel"
+                       :placeholder "No result"
+                       :value (or @content "")
+                       :rows (count (clj-str/split-lines @content))
+                       :fluid "true"
+                       :style {:border "none"}
+                       :readOnly true}]]))))
 
 (defn result-panel [width]
   [:> grid-column {:width width}

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -3,6 +3,7 @@
    [reagent.core :as reagent]
    [re-frame.core :as re-frame]
    [metafacture-playground.subs :as subs]
+   [metafacture-playground.events :as events]
    [clojure.string :as clj-str]
    [lambdaisland.uri :refer [uri]]
    [cljsjs.semantic-ui-react]
@@ -78,7 +79,7 @@
   (let [collapsed? (re-frame/subscribe [::subs/collapsed? panel-path])]
     [:> label
      {:attached "top right"
-      :on-click #(re-frame/dispatch [:collapse-panel panel-path @collapsed?])}
+      :on-click #(re-frame/dispatch [::events/collapse-panel panel-path @collapsed?])}
      [:> icon
       {:name
        (if @collapsed?
@@ -121,7 +122,7 @@
         flux (re-frame/subscribe [::subs/field-value :flux])
         fix  (re-frame/subscribe [::subs/field-value :fix])]
     [simple-button {:content "Process"
-                    :dispatch-fn [:process @data @flux @fix]
+                    :dispatch-fn [::events/process @data @flux @fix]
                     :icon-name "play"}]))
 
 (defn share-link [link-type label-text]
@@ -135,7 +136,7 @@
       {:id (str link-type "-link-input")
        :action {:color color
                 :icon "copy"
-                :on-click #(re-frame/dispatch [:copy-link @link])
+                :on-click #(re-frame/dispatch [::events/copy-link @link])
                 :alt "Copy link"
                 :disabled (not @link)}
        :placeholder (if-not @link "Nothing to share..." "")
@@ -157,12 +158,12 @@
       :on "click"
       :position "bottom left"
       :wide "very"
-      :trigger (reagent/as-element (simple-button {:content "Share" :icon-name "share alternate" :dispatch-fn [:generate-links uri @data @flux @fix]}))}]))
+      :trigger (reagent/as-element (simple-button {:content "Share" :icon-name "share alternate" :dispatch-fn [::events/generate-links uri @data @flux @fix]}))}]))
 
 (defn control-panel []
   [:> segment {:raised true}
-   [simple-button {:content "Load sample" :dispatch-fn [:load-sample] :icon-name "code"}]
-   [simple-button {:content "Clear all" :dispatch-fn [:clear-all] :icon-name "erase"}]
+   [simple-button {:content "Load sample" :dispatch-fn [::events/load-sample] :icon-name "code"}]
+   [simple-button {:content "Clear all" :dispatch-fn [::events/clear-all] :icon-name "erase"}]
    [process-button]
    [share-button]])
 
@@ -189,8 +190,8 @@
            :fluid "true"
            :rows rows
            :on-change #(do
-                         (re-frame/dispatch-sync [:edit-input-value (keyword name) (-> % .-target .-value)])
-                         (re-frame/dispatch-sync [:update-cursor-position
+                         (re-frame/dispatch-sync [::events/edit-input-value (keyword name) (-> % .-target .-value)])
+                         (re-frame/dispatch-sync [::events/update-cursor-position
                                                   (keyword name)
                                                   (-> % .-target .-selectionStart)]))}]])})))
 


### PR DESCRIPTION
- Use consistent namespacing for events, subscriptions and effects
- Transform form-2 render functions into form-1 render functions