### PR TITLE
Handle too long http links

### DIFF
--- a/src/clj/metafacture_playground/process.clj
+++ b/src/clj/metafacture_playground/process.clj
@@ -52,18 +52,9 @@
       output)]))
 
 (defn- process-flux [file-path out-path]
-  (try
-    (Flux/main (into-array [file-path]))
-    (println "Processed flux file.")
-    (slurp out-path)
-    (catch Exception e
-      (println "Something went wrong: " (.getMessage e))
-      (println "Exception: " (.printStackTrace e))
-      (str "Sorry, something went wrong: " (.getMessage e)))
-    (catch Error e
-      (println "Something really went wrong: " (.getMessage e))
-      (println "Error: " (.printStackTrace e))
-      (str "Sorry, something went wrong: " (.getMessage e)))))
+  (Flux/main (into-array [file-path]))
+  (println "Processed flux file.")
+  (slurp out-path))
 
 (defn process [data flux fix]
   (let [[out-path flux-content] (->flux-content data flux fix)]

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -19,4 +19,5 @@
            :workflow nil}
    :result {:loading? false
             :collapsed? false
-            :content nil}})
+            :content nil}
+   :message nil})

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -20,4 +20,5 @@
    :result {:loading? false
             :collapsed? false
             :content nil}
-   :message nil})
+   :message {:content nil
+             :type nil}})

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -183,10 +183,12 @@
    process-response)
 
 (defn bad-response
-  [{db :db} [_ response]]
+  [{db :db} [_ {:keys [status status-text]}]]
   {:db (-> db
            (assoc-in [:result :loading?] false)
-           (assoc-in [:result :content] "Bad response"))})
+           (assoc :message (str "Response from Server: "
+                                "Status-Code \"" status "\" with "
+                                "Status-Text \"" status-text \")))})
 
 (re-frame/reg-event-fx
  ::bad-response

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -155,8 +155,6 @@
 
 (defn process-response
   [{db :db} [_ response]]
-  (println "pricess repsonse")
-
   {:db (-> db
            (assoc-in [:result :loading?] false)
            (assoc-in [:result :content] response))})

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -160,7 +160,8 @@
         url-string-too-long? (or (> (count api-call-link) max-url-string)
                                  (> (count workflow-link) max-url-string))
         message (when (or query-string-too-long? url-string-too-long?)
-                  "Share links for large workflows are not supported yet")]
+                  {:content "Share links for large workflows are not supported yet"
+                   :type :warning})]
     {:db (-> db
              (assoc :message message)
              (assoc-in [:links :api-call] (when-not url-string-too-long? api-call-link))
@@ -186,9 +187,10 @@
   [{db :db} [_ {:keys [status status-text]}]]
   {:db (-> db
            (assoc-in [:result :loading?] false)
-           (assoc :message (str "Response from Server: "
-                                "Status-Code \"" status "\" with "
-                                "Status-Text \"" status-text \")))})
+           (assoc :message {:content (str "Response from Server with "
+                                          "Status-Code \"" status "\" and "
+                                          "Status-Text \"" status-text \")
+                            :type :error}))})
 
 (re-frame/reg-event-fx
  ::bad-response

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -3,6 +3,11 @@
    [re-frame.core :as re-frame]))
 
 (re-frame/reg-sub
+  ::message
+  (fn [db _]
+    (get db :message)))
+
+(re-frame/reg-sub
   ::field-value
   (fn [db [_ field-name]]
     (get-in db [:input-fields field-name :content])))

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -42,6 +42,7 @@
 (def image (component "Image"))
 (def input (component "Input"))
 (def popup (component "Popup"))
+(def message (component "Message"))
 
 ;;; Using monaco editor react component
 
@@ -140,6 +141,14 @@
               :src "images/metafacture-logo.png"}]
    "Metafacture Playground"])
 
+;;; Message Panel
+
+(defn message-panel []
+  (let [current-message (re-frame/subscribe [::subs/message])]
+    (when @current-message
+      [:> message {:content @current-message
+                   :on-dismiss #(re-frame/dispatch [::events/dismiss-message])}])))
+
 ;;; Control Panel
 
 (defn process-button []
@@ -171,7 +180,7 @@
                 :alt "Copy link"
                 :disabled (not @link)}
        :placeholder (if-not @link "Nothing to share..." "")
-       :default-value (or @link "")
+       :value (or @link "")
        :readOnly true}]]))
 
 (defn share-links []
@@ -288,6 +297,8 @@
    [:> segment
 
     [page-header]
+
+    [message-panel]
 
     [control-panel]
 

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -143,11 +143,28 @@
 
 ;;; Message Panel
 
+(defn- message-content [content type]
+  (case type
+    :error (str "ERROR: " content)
+    :warning (str "WARNING: " content)
+    :info (str "INFO: " content)
+    :success (str "SUCCESS: " content)
+    content))
+
+(defn- message-type [type]
+  (case type
+    :error {:error true}
+    :warning {:warning true}
+    :info {:info true}
+    :success {:success true}
+    nil))
+
 (defn message-panel []
-  (let [current-message (re-frame/subscribe [::subs/message])]
-    (when @current-message
-      [:> message {:content @current-message
-                   :on-dismiss #(re-frame/dispatch [::events/dismiss-message])}])))
+  (let [{:keys [content type]} @(re-frame/subscribe [::subs/message])]
+    (when content
+      [:> message (merge {:content (message-content content type)
+                          :on-dismiss #(re-frame/dispatch [::events/dismiss-message])}
+                         (message-type type))])))
 
 ;;; Control Panel
 

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -4,6 +4,12 @@
             [metafacture-playground.events :as events]
             [lambdaisland.uri :refer [uri query-string->map]]))
 
+; Utils
+
+(defn- generate-random-string [length]
+  (->> (repeat length \a)
+       (apply str)))
+
 ; Initilized db = empty db
 (def empty-db
   (events/initialize-db {:dbh {}
@@ -65,14 +71,14 @@
   (testing "Test loading sample with part of fields not empty."
     (let [db' (-> db1
                   (events/load-sample [:load-sample db/sample-fields])
-                  (update :db dissoc :result :links :storage/set)
+                  (update :db dissoc :result :links :storage/set :message)
                   (dissoc :storage/set))]
       (is (= (:db db') (:db db-with-sample)))))
 
   (testing "Test loading sample with all fields not empty."
     (let [db' (-> db2
                   (events/load-sample [:load-sample db/sample-fields])
-                  (update :db dissoc :result :links :storage/set))]
+                  (update :db dissoc :result :links :storage/set :message))]
       (is (= (:db db') (:db db-with-sample))))))
 
 
@@ -131,4 +137,29 @@
            (is (= (-> workflow-link :query query-string->map :data) data))
            (is (= (-> workflow-link :query query-string->map :flux) flux))
            (is (= (-> workflow-link :query query-string->map :fix) fix))
-           (is (= (:path workflow-link) "/test/"))))))
+           (is (= (:path workflow-link) "/test/")))))
+
+  (testing "Test not generating links if parameters are too long "
+    (let [db' (-> empty-db
+                  (events/edit-value [:edit-value :data (generate-random-string 1025)]))
+          data (get-in db' [:db :input-fields :data :content])
+          db'' (-> db'
+                   (events/generate-links [:generate-links "https://metafacture-playground.com/test/" data nil nil])
+                   :db)]
+      (and (is (= (:message db'') "Share links for large workflows are not supported yet"))
+           (is (nil? (get-in db'' [:links :api-call])))
+           (is (nil? (get-in db'' [:links :workflow]))))))
+
+  (testing "Test not generating links if url is too long "
+    (let [db' (-> empty-db
+                  (events/load-sample [:load-sample db/sample-fields]))
+          data (get-in db' [:db :input-fields :data :content])
+          fix (get-in db' [:db :input-fields :fix :content])
+          flux (get-in db' [:db :input-fields :flux :content])
+          extra-long-test-url (str "https://metafacture-playground.com/" (generate-random-string 1671) "/")
+          db'' (-> db'
+                   (events/generate-links [:generate-links extra-long-test-url data flux fix])
+                   :db)]
+      (and (is (= (:message db'') "Share links for large workflows are not supported yet"))
+           (is (nil? (get-in db'' [:links :api-call])))
+           (is (nil? (get-in db'' [:links :workflow])))))))

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -146,7 +146,7 @@
           db'' (-> db'
                    (events/generate-links [:generate-links "https://metafacture-playground.com/test/" data nil nil])
                    :db)]
-      (and (is (= (:message db'') "Share links for large workflows are not supported yet"))
+      (and (is (= (get-in db'' [:message :content]) "Share links for large workflows are not supported yet"))
            (is (nil? (get-in db'' [:links :api-call])))
            (is (nil? (get-in db'' [:links :workflow]))))))
 
@@ -160,6 +160,6 @@
           db'' (-> db'
                    (events/generate-links [:generate-links extra-long-test-url data flux fix])
                    :db)]
-      (and (is (= (:message db'') "Share links for large workflows are not supported yet"))
+      (and (is (= (get-in db'' [:message :content]) "Share links for large workflows are not supported yet"))
            (is (nil? (get-in db'' [:links :api-call])))
            (is (nil? (get-in db'' [:links :workflow])))))))


### PR DESCRIPTION
- warn if share links are too long (resolves #35)
- display the http status codes of bad http responses as message and not as result