### PR TITLE
Support long workflow inputs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [reagent "0.10.0"]
                  [re-frame "1.1.2"]
                  [yogthos/config "1.1.7"]
-                 [ring "1.8.2"]
+                 [ring "1.9.0"]
                  [compojure "1.6.2"]
                  [lambdaisland/uri "1.4.54"]
                  [day8.re-frame/fetch-fx "0.0.1"]

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -230,6 +230,13 @@
    0
    params))
 
+(defn- query-string-too-long? [params maximum]
+  (try
+    (> (count-query-string params)
+       maximum)
+    (catch js/RangeError _
+      true)))
+
 (defn generate-link [url path query-params]
   (-> (uri url)
       (join path)
@@ -248,10 +255,8 @@
                                (when fix {:fix fix})
                                (when morph {:morph morph})
                                {:active-editor (name active-editor)})
-        api-call-query-string-too-long? (> (count-query-string api-call-params)
-                                           max-query-string)
-        workflow-query-string-too-long? (> (count-query-string workflow-params)
-                                           max-query-string)
+        api-call-query-string-too-long? (query-string-too-long? api-call-params max-query-string)
+        workflow-query-string-too-long? (query-string-too-long? workflow-params max-query-string)
         api-call-link (when (and api-call-params (not api-call-query-string-too-long?))
                         (generate-link url "./process" api-call-params))
         workflow-link (when (and workflow-params (not workflow-query-string-too-long?))

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -144,7 +144,8 @@
   [{db :db} [_ sample]]
   {:db (add-sample db sample)
    :storage/set {:session? true
-                 :pairs (generate-pairs {:input-fields sample})}
+                 :pairs (-> {:input-fields (update-in sample [:switch :active] name)}
+                            generate-pairs)}
    :dispatch-n (mapv
                 (fn [editor]
                   [::update-width editor (get-in sample [editor :content])])
@@ -362,7 +363,10 @@
     web-storage :storage/all}]
   (let [query-params (-> href uri :query query-string->map)]
     (if (empty? query-params)
-      {:db (deep-merge db/default-db (restore-db web-storage) {:ui {:height window-height}})}
+      {:db (deep-merge
+            db/default-db
+            (restore-db web-storage)
+            {:ui {:height window-height}})}
       {:db (-> db/default-db
                (assoc-query-params query-params)
                (assoc-in [:ui :height] window-height))


### PR DESCRIPTION
Resolves #48

- Switch from GET to POST requests for workflow processing
- Catch RangeError when inputs are too long to count for generating links
- Fix display bug: loading the sample data and reloading after that led to neither fix nor morph editor to be selected