### PR TITLE
Add directories for examples

### DIFF
--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -26,7 +26,7 @@
              :type nil}
    :ui {:height nil
         :dropdown {:active-item nil
-                   :open? false}}})
+                   "main" {:open? false}}}})
 
 (defn- parseBoolean [val]
   (if (= val "true")

--- a/src/cljs/metafacture_playground/db.cljs
+++ b/src/cljs/metafacture_playground/db.cljs
@@ -56,4 +56,4 @@
    :message {:content str
              :type keyword}
    :ui {:height parseBoolean
-        :dropdown {:active-item str}}})
+        :dropdown {:active-item #(if (= "" %) nil (str %))}}})

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -129,7 +129,7 @@
 ;;; Editing input fields
 
 (defn edit-value
-  [{db :db} [_ field-name new-value]]
+  [{db :db} [_ field-name new-value & is-example-data?]]
   (let [db-path [:input-fields field-name :content]
         disable-editors (when (= field-name :flux)
                           (let [val (-> new-value
@@ -141,19 +141,21 @@
                             {[:input-fields :data :disabled?] (not data-used?)
                              [:input-fields :morph :disabled?] (not morph-used?)
                              [:input-fields :fix :disabled?] (not fix-used?)}))]
-    {:db (-> (reduce
-              (fn [db [path v]]
-                (assoc-in db path v))
-              db
-              disable-editors)
-             (assoc-in db-path new-value))
+    {:db (cond-> (reduce
+                  (fn [db [path v]]
+                    (assoc-in db path v))
+                  db
+                  disable-editors)
+           true (assoc-in db-path new-value)
+           (not is-example-data?) (assoc-in [:ui :dropdown :active-item] nil))
      :storage/set {:session? true
                    :pairs (conj
                            (mapv
                             (fn [[db-path v]]
                               {:name (->storage-key db-path) :value v})
                             disable-editors)
-                           {:name (->storage-key db-path) :value new-value})}
+                           {:name (->storage-key db-path) :value new-value}
+                           (when-not is-example-data? {:name (->storage-key [:ui :dropdown :active-item]) :value nil}))}
      :dispatch [::update-width field-name new-value]}))
 
 (re-frame/reg-event-fx
@@ -176,7 +178,7 @@
      :fx (conj
           (mapv
            (fn [editor]
-             [:dispatch [::edit-input-value editor (get sample editor "")]])
+             [:dispatch [::edit-input-value editor (get sample editor "") true]])
            [:data :flux :fix :morph])
           [:dispatch [::switch-editor (:active-editor sample)]])
      :storage/set {:session? true
@@ -205,7 +207,8 @@
                         [[:input-fields :switch :width] nil]]
         storage-set [[[:input-fields :data :disabled?] true]
                      [[:input-fields :fix :disabled?] true]
-                     [[:input-fields :morph :disabled?] true]]
+                     [[:input-fields :morph :disabled?] true]
+                     [[:ui :dropdown :active-item] nil]]
         other [[[:result :content] nil]
                [[:links :api-call] nil]
                [[:links :workflow] nil]]]

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -227,13 +227,14 @@
 
 (defn switch-editor
   [{db :db} [_ editor]]
-  (merge
-   {:db (assoc-in db [:input-fields :switch :active] editor)
-    :storage/set {:session? true
-                  :name (->storage-key [:input-fields :switch :active])
-                  :value (when editor (name editor))}}
-   (when editor
-     {:dispatch [::update-width editor (get-in db [:input-fields editor :content])]})))
+  (let [editor (or editor :fix)]
+    (merge
+     {:db (assoc-in db [:input-fields :switch :active] editor)
+      :storage/set {:session? true
+                    :name (->storage-key [:input-fields :switch :active])
+                    :value (when editor (name editor))}}
+     (when editor
+       {:dispatch [::update-width editor (get-in db [:input-fields editor :content])]}))))
 
 (re-frame/reg-event-fx
  ::switch-editor

--- a/src/cljs/metafacture_playground/events.cljs
+++ b/src/cljs/metafacture_playground/events.cljs
@@ -161,8 +161,8 @@
  edit-value)
 
 (defn open-dropdown
-  [{db :db} [_ status]]
-  {:db (assoc-in db [:ui :dropdown :open?] status)})
+  [{db :db} [_ folder status]]
+  {:db (assoc-in db [:ui :dropdown folder :open?] status)})
 
 (re-frame/reg-event-fx
  ::open-dropdown

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -28,19 +28,27 @@
 
 (re-frame/reg-sub
  ::dropdown-open?
- (fn [db _]
-   (get-in db [:ui :dropdown :open?])))
+ (fn [db [_ folder]]
+   (get-in db [:ui :dropdown folder :open?])))
 
 (defn- display-name [str]
   (clj-str/replace str "_" " "))
+
+(defn- examples->dropdown-entries []
+  (map
+   (fn [[k v]]
+     (if (map? v)
+       {k (into (sorted-map)
+                (examples->dropdown-entries)
+                v)}
+       {k {:display-name (display-name k)
+           :value (utils/parse-url v)}}))))
 
 (re-frame/reg-sub
  ::examples
  (fn [db _]
    (into (sorted-map)
-         (map (fn [[k v]]
-                {k {:display-name (display-name k)
-                    :value (utils/parse-url v)}}))
+         (examples->dropdown-entries)
          (get db :examples))))
 
 (re-frame/reg-sub

--- a/test/cljs/metafacture_playground/event_handler_test.cljs
+++ b/test/cljs/metafacture_playground/event_handler_test.cljs
@@ -87,7 +87,7 @@
                  (:flux sample-data)))
           (is (= @(re-frame/subscribe [::subs/field-value :fix])
                  (:fix sample-data)))
-          (is (not @(re-frame/subscribe [::subs/dropdown-open?])))
+          (is (not @(re-frame/subscribe [::subs/dropdown-open? "main"])))
           (is (= @(re-frame/subscribe [::subs/dropdown-active-item])
                  "sample data"))))))
 


### PR DESCRIPTION
- Resolves #77: every subfolder in the resources/examples folder will be shown in the ui
- Resolves #88: fix editor is set up as default editor, so it's not possible that none of both editors is selected
- Resolves #83: fixed behaviour of active-item of the dropdown after clear, import or editing in an editor
