### PR TITLE
Add short share links for named examples

### DIFF
--- a/src/cljs/metafacture_playground/effects.cljs
+++ b/src/cljs/metafacture_playground/effects.cljs
@@ -1,6 +1,7 @@
 (ns metafacture-playground.effects
   (:require [re-frame.core :as re-frame]
-            [clojure.string :as clj-str]))
+            [clojure.string :as clj-str]
+            [lambdaisland.uri :refer [uri assoc-query*]]))
 
 (re-frame/reg-fx
  ::copy-to-clipboard
@@ -14,9 +15,17 @@
 
 (re-frame/reg-fx
  ::unset-url-query-params
- (fn [href]
-   (let [new-href (clj-str/replace href #"\?.*" "")]
+ (fn [& [href]]
+   (let [href (or href (-> js/window .-location .-href))
+         new-href (clj-str/replace href #"\?.*" "")]
      (-> js/window .-history (.replaceState {} "" new-href)))))
+
+(re-frame/reg-fx
+ ::set-url-query-params
+ (fn [example]
+   (let [href (-> js/window .-location .-href)
+         href-with-params (-> href uri (assoc-query* {:example example}))]
+     (-> js/window .-history (.replaceState {} "" href-with-params)))))
 
 (defn- file-blob [datamap mimetype]
   (js/Blob. [datamap] {"type" mimetype}))

--- a/src/cljs/metafacture_playground/subs.cljs
+++ b/src/cljs/metafacture_playground/subs.cljs
@@ -1,8 +1,7 @@
 (ns metafacture-playground.subs
   (:require
    [re-frame.core :as re-frame]
-   [clojure.string :as clj-str]
-   [metafacture-playground.utils :as utils]))
+   [clojure.string :as clj-str]))
 
 (defn- expand-indentation [details]
   (when details
@@ -31,25 +30,10 @@
  (fn [db [_ folder]]
    (get-in db [:ui :dropdown folder :open?])))
 
-(defn- display-name [str]
-  (clj-str/replace str "_" " "))
-
-(defn- examples->dropdown-entries []
-  (map
-   (fn [[k v]]
-     (if (map? v)
-       {k (into (sorted-map)
-                (examples->dropdown-entries)
-                v)}
-       {k {:display-name (display-name k)
-           :value (utils/parse-url v)}}))))
-
 (re-frame/reg-sub
  ::examples
  (fn [db _]
-   (into (sorted-map)
-         (examples->dropdown-entries)
-         (get db :examples))))
+   (get db :examples)))
 
 (re-frame/reg-sub
  ::editor-key

--- a/src/cljs/metafacture_playground/utils.cljs
+++ b/src/cljs/metafacture_playground/utils.cljs
@@ -1,6 +1,10 @@
 (ns metafacture-playground.utils
   (:require
-   [lambdaisland.uri :refer [uri query-string->map]]))
+   [lambdaisland.uri :refer [uri query-string->map]]
+   [clojure.string :as clj-str]))
+
+(defn display-name [s]
+  (clj-str/replace s "_" " "))
 
 (defn parse-url [href]
   (let [query-params (-> href

--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -10,7 +10,7 @@
    [goog.object :as g]
    [re-pressed.core :as rp]
    ["@monaco-editor/react" :as monaco-react]
-   [cljs.pprint :as pprint]))
+   [metafacture-playground.utils :as utils]))
 
 ;;; Using semantic ui react components
 
@@ -201,7 +201,10 @@
 
 (defn is-group? [entry]
   (try
-    (when (-> entry val :display-name) false)
+    (when (or (-> entry val :data)
+              (-> entry val :flux)
+              (-> entry val :fix)
+              (-> entry val :morph)) false)
     (catch :default _
       true)))
 
@@ -217,9 +220,8 @@
                          :item true
                          :on-click #(re-frame/dispatch [::events/open-dropdown (key entry) (not @dropdown-open?)])}
             (dropdown-entries (val entry))])
-        (let [[k v] entry
-              display-name (:display-name v)
-              value (:value v)
+        (let [[k _] entry
+              display-name (utils/display-name k)
               dropdown-value (re-frame/subscribe [::subs/dropdown-active-item])]
           ^{:key k}
           [:> dropdown-item
@@ -228,7 +230,7 @@
             :value display-name
             :active (= display-name @dropdown-value)
             :selected (= display-name @dropdown-value)
-            :onClick #(re-frame/dispatch [::events/load-sample display-name value])}]))))])
+            :onClick #(re-frame/dispatch [::events/load-example display-name])}]))))])
 
 (defn examples-dropdown []
   [:> button-group {:color color


### PR DESCRIPTION
If an example is selected, a new query parameter `example` is displayed in the URL, which can be shared.
Closes #115 