### PR TITLE
Add note re docker logs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ docker compose up
 
 In production mode the ***local deployment*** is available at http://localhost:3000.
 
+### View output (logs) from Docker container
+
+```bash
+docker compose logs --timestamps
+```
+
+For more options see https://docs.docker.com/reference/cli/docker/compose/logs/
+
 ## Manual installation
 
 Before starting you need to install [Leiningen](https://leiningen.org/) and a JDK (minimum Java 11).


### PR DESCRIPTION
The dockerised playground uses plain `lein run` to start the app inside the container, see https://github.com/metafacture/metafacture-playground/blob/main/Dockerfile.prod#L57. 
If you want to view the output of this command use `docker compose logs` on the host. Useful options are `-f` (like tail -f) and `-t´ (show timestamps), for more see https://docs.docker.com/reference/cli/docker/compose/logs/

This will replace our current usage of `nohup lein run &`.