### PR TITLE
Add volume (bind mount) for tmp directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     volumes:
       - '/etc/timezone:/etc/timezone:ro' # Sync with host
       - '/etc/localtime:/etc/localtime:ro' # Sync with host
+      - './tmp:/home/playground/metafacture-playground/tmp'
     deploy:
       resources:
         limits:


### PR DESCRIPTION
tmp directory will be created on the host
you might need to adjust permissions of this directory otherwise the playground user inside the container won't be allowed to write to the tmp directory

As a workaround for #158
Remove tmp files using cron