### PR TITLE
Fix missing use of shadow content for data editor

### DIFF
--- a/src/cljs/metafacture_playground/views.cljs
+++ b/src/cljs/metafacture_playground/views.cljs
@@ -267,7 +267,7 @@
 
 (defn share-button []
   (let [uri (-> js/window .-location .-href uri (assoc :query nil))
-        data (re-frame/subscribe [::subs/editor-content :data])
+        data (re-frame/subscribe [::subs/editor-shadow-content :data])
         data-variable (re-frame/subscribe [::subs/file-variable :data])
         flux (re-frame/subscribe [::subs/editor-shadow-content :flux])
         transformation (re-frame/subscribe [::subs/editor-shadow-content :transformation])


### PR DESCRIPTION
In #184 we changed the behaviour of storing the content of the monaco editors and missed changing it for the data input for the share link button. That's done now in this pr.
Resolves #235 