### PR TITLE
Update Docker base image #242 #245

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,28 +1,12 @@
-FROM debian:bookworm-slim
+FROM eclipse-temurin:11-jdk-jammy
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common \
-    wget \
-    gnupg \
+RUN apt-get update && apt-get install -y \
     leiningen \
     git \
-    vim \
     curl \
     unzip \
-    ca-certificates \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# OpenJDK 11 manuell installieren
-RUN wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
- && tar xzf openjdk-11.0.2_linux-x64_bin.tar.gz -C /opt \
- && rm openjdk-11.0.2_linux-x64_bin.tar.gz \
- && update-alternatives --install /usr/bin/java java /opt/jdk-11.0.2/bin/java 1 \
- && update-alternatives --install /usr/bin/javac javac /opt/jdk-11.0.2/bin/javac 1
-
-# Node.js 18 installieren über Nodesource
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Use non-root user

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,28 +1,12 @@
-FROM debian:bookworm-slim
+FROM eclipse-temurin:11-jdk-jammy
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    software-properties-common \
-    wget \
-    gnupg \
+RUN apt-get update && apt-get install -y \
     leiningen \
     git \
-    vim \
     curl \
     unzip \
-    ca-certificates \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# OpenJDK 11 manuell installieren
-RUN wget https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz \
- && tar xzf openjdk-11.0.2_linux-x64_bin.tar.gz -C /opt \
- && rm openjdk-11.0.2_linux-x64_bin.tar.gz \
- && update-alternatives --install /usr/bin/java java /opt/jdk-11.0.2/bin/java 1 \
- && update-alternatives --install /usr/bin/javac javac /opt/jdk-11.0.2/bin/javac 1
-
-# Node.js 18 installieren über Nodesource
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
 # Use non-root user


### PR DESCRIPTION
By using `eclipse-temurin:11-jdk-jammy` as base image we also get rid off the erroneous installations of Java 11 and Nodejs

Resolves #242 
Resolves #245 