### PR TITLE
Display documentation of completion item

### DIFF
--- a/src/cljs/ls_client/monaco_integration.cljs
+++ b/src/cljs/ls_client/monaco_integration.cljs
@@ -72,7 +72,7 @@
     #js {:label label
          :insertText (get* "insertText" item)
          :detail detail
-         :documentation detail
+         :documentation (get* "documentation" item)
          :sortText (get* "sortText" item)
          :filterText label
          :kind (get* "kind" item)}))


### PR DESCRIPTION
Displays by server delivered `documentation` as documentation instead of `details` twice.
Resolves #262 